### PR TITLE
Bytecode compilation target for MQL

### DIFF
--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/AsmUtil.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/AsmUtil.java
@@ -1,0 +1,97 @@
+package net.hollowcube.mql.compile;
+
+import org.jetbrains.annotations.NotNull;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.util.TraceClassVisitor;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+final class AsmUtil {
+    private AsmUtil() {}
+
+    public static @NotNull String toDescriptor(@NotNull Class<?> clazz) {
+        if (boolean.class.equals(clazz)) {
+            return "Z";
+        } else if (byte.class.equals(clazz)) {
+            return "B";
+        } else if (char.class.equals(clazz)) {
+            return "C";
+        } else if (short.class.equals(clazz)) {
+            return "S";
+        } else if (int.class.equals(clazz)) {
+            return "I";
+        } else if (long.class.equals(clazz)) {
+            return "J";
+        } else if (float.class.equals(clazz)) {
+            return "F";
+        } else if (double.class.equals(clazz)) {
+            return "D";
+        } else if (void.class.equals(clazz)) {
+            return "V";
+        }
+        return "L" + toName(clazz) + ";";
+    }
+
+    public static @NotNull String toName(@NotNull Class<?> clazz) {
+        return clazz.getName().replace(".", "/");
+    }
+
+    @SuppressWarnings("all")
+    public static <_Query, _Context> Class<MqlScript<_Query, _Context>> loadClass(String className, byte[] b) {
+        // Override defineClass (as it is protected) and define the class.
+        Class<MqlScript<_Query, _Context>> clazz = null;
+        try {
+            ClassLoader loader = ClassLoader.getSystemClassLoader();
+            Class<MqlScript<_Query, _Context>> cls = (Class<MqlScript<_Query, _Context>>) Class.forName("java.lang.ClassLoader");
+            java.lang.reflect.Method method =
+                    cls.getDeclaredMethod(
+                            "defineClass",
+                            new Class[] { String.class, byte[].class, int.class, int.class });
+
+            // Protected method invocation.
+            method.setAccessible(true);
+            try {
+                Object[] args =
+                        new Object[] { className, b, 0, b.length};
+                clazz = (Class<MqlScript<_Query, _Context>>) method.invoke(loader, args);
+            } finally {
+                method.setAccessible(false);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+        return clazz;
+    }
+
+    public static class StringClassVisitor extends ClassVisitor {
+        private final ClassWriter cw;
+        private final StringWriter sw;
+
+        public StringClassVisitor() {
+            this(new ClassWriter(ClassWriter.COMPUTE_MAXS), new StringWriter());
+        }
+
+        public StringClassVisitor(ClassWriter cw) {
+            this(cw, new StringWriter());
+        }
+
+        private StringClassVisitor(ClassWriter cw, StringWriter sw) {
+            super(Opcodes.ASM9, new TraceClassVisitor(cw, new PrintWriter(sw)));
+            this.cw = cw;
+            this.sw = sw;
+        }
+
+        public ClassWriter classWriter() {
+            return cw;
+        }
+
+        public String bytecode() {
+            return sw.toString();
+        }
+    }
+
+}

--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/Context.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/Context.java
@@ -1,0 +1,99 @@
+package net.hollowcube.mql.compile;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.UnknownNullability;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+
+import static org.objectweb.asm.Opcodes.*;
+
+final class Context {
+    private final Class<?> queryClass; // Class mapped to `query`
+    private final Class<?> contextClass; // Class mapped to `context`
+
+    private final String className;
+    private final ClassVisitor scriptClass;
+    private MethodVisitor evalMethod;
+
+    public Context(@NotNull Class<?> queryClass, @Nullable Class<?> contextClass) {
+        this(queryClass, contextClass, new ClassWriter(ClassWriter.COMPUTE_MAXS));
+    }
+
+    public Context(@NotNull Class<?> queryClass, @Nullable Class<?> contextClass, @NotNull ClassVisitor builder) {
+        this.queryClass = queryClass;
+        this.contextClass = contextClass == null ? Void.class : contextClass;
+        this.className = "mql$todo_add_better_name";
+        this.scriptClass = builder;
+    }
+
+    public void begin() {
+        var sig = String.format("L%s<%s%s>;", AsmUtil.toName(MqlScript.class), AsmUtil.toDescriptor(queryClass), AsmUtil.toDescriptor(contextClass));
+        scriptClass.visit(V17, ACC_PUBLIC | ACC_FINAL, className, sig, "java/lang/Object", new String[]{AsmUtil.toName(MqlScript.class)});
+
+        generateSynthetics();
+
+        //todo if for any reason queryClass or contextClass has a generic parameter then this will fail because `signature` needs to be provided. Either can make this more robust or just disallow generic parameters on queryClass and contextClass.
+        evalMethod = scriptClass.visitMethod(ACC_PUBLIC, "evaluate", evaluateDescriptor(), null, null);
+        evalMethod.visitCode();
+    }
+
+    public byte[] end() {
+        evalMethod.visitInsn(DRETURN); // ok because all expressions leave a double on the stack
+        evalMethod.visitMaxs(0, 0);
+        evalMethod.visitEnd();
+
+        scriptClass.visitEnd();
+
+        if (scriptClass instanceof ClassWriter cw) {
+            return cw.toByteArray();
+        } else if (scriptClass instanceof AsmUtil.StringClassVisitor visitor) {
+            return visitor.classWriter().toByteArray();
+        } else {
+            throw new IllegalStateException("Cannot get bytecode from " + scriptClass.getClass().getName());
+        }
+    }
+
+    public @UnknownNullability MethodVisitor method() {
+        return evalMethod;
+    }
+
+    public @NotNull String queryClassName() {
+        return AsmUtil.toName(queryClass);
+    }
+
+    public @NotNull String contextClassName() {
+        return AsmUtil.toName(contextClass);
+    }
+
+    private void generateSynthetics() {
+        // Add empty constructor
+        var mv = scriptClass.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+        mv.visitCode();
+        mv.visitVarInsn(ALOAD, 0);
+        mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+        mv.visitInsn(RETURN);
+        mv.visitMaxs(1,1);
+        mv.visitEnd();
+
+        // Insert bridge method for evaluate
+        mv = scriptClass.visitMethod(ACC_PUBLIC | ACC_SYNTHETIC | ACC_BRIDGE, "evaluate", "(Ljava/lang/Object;Ljava/lang/Object;)D", null, null);
+        mv.visitCode();
+
+        mv.visitVarInsn(ALOAD, 0); // this
+        mv.visitVarInsn(ALOAD, 1); // query
+        mv.visitTypeInsn(CHECKCAST, AsmUtil.toName(queryClass));
+        mv.visitVarInsn(ALOAD, 2); // context
+        mv.visitTypeInsn(CHECKCAST, AsmUtil.toName(contextClass));
+        mv.visitMethodInsn(INVOKEVIRTUAL, className, "evaluate", evaluateDescriptor(), false);
+        mv.visitInsn(DRETURN);
+
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+    }
+
+    private String evaluateDescriptor() {
+        return String.format("(%s%s)D", AsmUtil.toDescriptor(queryClass), AsmUtil.toDescriptor(contextClass));
+    }
+}

--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlCompiler.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlCompiler.java
@@ -3,6 +3,8 @@ package net.hollowcube.mql.compile;
 import net.hollowcube.mql.parser.MqlParser;
 import net.hollowcube.mql.tree.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
+import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
@@ -29,6 +31,11 @@ public class MqlCompiler<_Query, _Context> {
     // Public API
 
     public @NotNull MqlScript<_Query, _Context> compile(@NotNull String source) {
+        throw new RuntimeException("not implemented");
+    }
+
+    @TestOnly
+    public byte[] compileBytecode(@NotNull String source) {
         String sourceHash = Integer.toHexString(source.hashCode());
         // Could cache based on the hash if compiling many times over is a valid use case, but I don't think it is.
 
@@ -39,7 +46,7 @@ public class MqlCompiler<_Query, _Context> {
         String className = "mql$" + sourceHash;
         ClassWriter scriptClass = new ClassWriter(ClassWriter.COMPUTE_MAXS);
         var sig = String.format("L%s<%s%s>;", getClassName(MqlScript.class), queryClass.descriptor(), contextClass.descriptor());
-        scriptClass.visit(V17, ACC_PUBLIC | ACC_FINAL, className, sig, getClassName(Object.class), new String[]{AsmUtil.toName(MqlScript.class)});
+        scriptClass.visit(V17, ACC_PUBLIC | ACC_FINAL | ACC_SYNTHETIC, className, sig, getClassName(Object.class), new String[]{AsmUtil.toName(MqlScript.class)});
 
         // Generate required synthetics
         generateSynthetics(className, scriptClass);
@@ -55,10 +62,7 @@ public class MqlCompiler<_Query, _Context> {
         // Finish the class and return it
         scriptClass.visitEnd();
 
-        byte[] bytecode = scriptClass.toByteArray();
-        //todo load class and return it
-
-        throw new RuntimeException("not implemented");
+        return scriptClass.toByteArray();
     }
 
     // Internal helpers

--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlCompiler.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlCompiler.java
@@ -74,7 +74,7 @@ public class MqlCompiler<_Query, _Context> {
         mv.visitVarInsn(ALOAD, 0);
         mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
         mv.visitInsn(RETURN);
-        mv.visitMaxs(1,1);
+        mv.visitMaxs(1, 1);
         mv.visitEnd();
 
         // Insert bridge method for evaluate
@@ -117,6 +117,9 @@ public class MqlCompiler<_Query, _Context> {
             // Perform the operation
             switch (expr.operator()) {
                 case PLUS -> method.visitInsn(DADD);
+                case MINUS -> method.visitInsn(DSUB);
+                case MUL -> method.visitInsn(DMUL);
+                case DIV -> method.visitInsn(DDIV);
             }
 
             return null;

--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlCompiler.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlCompiler.java
@@ -1,0 +1,55 @@
+package net.hollowcube.mql.compile;
+
+import net.hollowcube.mql.tree.*;
+import org.jetbrains.annotations.NotNull;
+import org.objectweb.asm.Opcodes;
+
+public class MqlCompiler implements MqlVisitor<Context, Void> {
+    @Override
+    public Void visitBinaryExpr(@NotNull MqlBinaryExpr expr, Context ctx) {
+        visit(expr.lhs(), ctx);
+        visit(expr.rhs(), ctx);
+
+        var method = ctx.method();
+        switch (expr.operator()) {
+            case PLUS -> method.visitInsn(Opcodes.DADD);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visitAccessExpr(@NotNull MqlAccessExpr expr, Context ctx) {
+        if (expr.lhs() instanceof MqlIdentExpr ident) {
+            if (!ident.value().equals("q")) {
+                throw new UnsupportedOperationException("Only q is supported as a query object");
+            }
+
+            var method = ctx.method();
+            method.visitVarInsn(Opcodes.ALOAD, 1);
+            method.visitMethodInsn(Opcodes.INVOKEVIRTUAL, ctx.queryClassName(), expr.target(), "()D", false);
+        } else {
+            throw new RuntimeException("Not implemented");
+        }
+        System.out.println("ACCESS " + expr.lhs() + " " + expr.target());
+        return null;
+    }
+
+    @Override
+    public Void visitNumberExpr(@NotNull MqlNumberExpr expr, Context ctx) {
+        var method = ctx.method();
+        method.visitLdcInsn(expr.value().value());
+        return null;
+    }
+
+    @Override
+    public Void visitRefExpr(@NotNull MqlIdentExpr expr, Context ctx) {
+        System.out.println("REF");
+        return null;
+    }
+
+    @Override
+    public Void defaultValue() {
+        return null;
+    }
+}

--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlCompilerOld.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlCompilerOld.java
@@ -1,0 +1,55 @@
+package net.hollowcube.mql.compile;
+
+import net.hollowcube.mql.tree.*;
+import org.jetbrains.annotations.NotNull;
+import org.objectweb.asm.Opcodes;
+
+public class MqlCompilerOld implements MqlVisitor<Context, Void> {
+    @Override
+    public Void visitBinaryExpr(@NotNull MqlBinaryExpr expr, Context ctx) {
+        visit(expr.lhs(), ctx);
+        visit(expr.rhs(), ctx);
+
+        var method = ctx.method();
+        switch (expr.operator()) {
+            case PLUS -> method.visitInsn(Opcodes.DADD);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visitAccessExpr(@NotNull MqlAccessExpr expr, Context ctx) {
+        if (expr.lhs() instanceof MqlIdentExpr ident) {
+            if (!ident.value().equals("q")) {
+                throw new UnsupportedOperationException("Only q is supported as a query object");
+            }
+
+            var method = ctx.method();
+            method.visitVarInsn(Opcodes.ALOAD, 1);
+            method.visitMethodInsn(Opcodes.INVOKEVIRTUAL, ctx.queryClassName(), expr.target(), "()D", false);
+        } else {
+            throw new RuntimeException("Not implemented");
+        }
+        System.out.println("ACCESS " + expr.lhs() + " " + expr.target());
+        return null;
+    }
+
+    @Override
+    public Void visitNumberExpr(@NotNull MqlNumberExpr expr, Context ctx) {
+        var method = ctx.method();
+        method.visitLdcInsn(expr.value().value());
+        return null;
+    }
+
+    @Override
+    public Void visitRefExpr(@NotNull MqlIdentExpr expr, Context ctx) {
+        System.out.println("REF");
+        return null;
+    }
+
+    @Override
+    public Void defaultValue() {
+        return null;
+    }
+}

--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlScript.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlScript.java
@@ -1,0 +1,9 @@
+package net.hollowcube.mql.compile;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface MqlScript<_Query, _Context> {
+
+    double evaluate(@NotNull _Query query, @NotNull _Context context);
+
+}

--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlScript.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/MqlScript.java
@@ -4,6 +4,14 @@ import org.jetbrains.annotations.NotNull;
 
 public interface MqlScript<_Query, _Context> {
 
+    MqlScript<Object, Object> EMPTY = (unused1, unused2) -> 1.0;
+
     double evaluate(@NotNull _Query query, @NotNull _Context context);
+
+
+    //todo perhaps should be MqlScript is the factory, and MqlScriptInstance is the actual script instance or something
+    interface Factory<_Query, _Context> {
+        @NotNull MqlScript<_Query, _Context> create();
+    }
 
 }

--- a/modules/mql/src/main/java/net/hollowcube/mql/compile/TestEntityQuery.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/compile/TestEntityQuery.java
@@ -1,0 +1,13 @@
+package net.hollowcube.mql.compile;
+
+import net.hollowcube.mql.foreign.Query;
+
+public class TestEntityQuery {
+
+    @Query
+    public double is_alive() {
+        System.out.println("IM STILL ALIVE");
+        return 1.0;
+    }
+
+}

--- a/modules/mql/src/main/java/net/hollowcube/mql/tree/MqlVisitor.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/tree/MqlVisitor.java
@@ -20,7 +20,7 @@ public interface MqlVisitor<P, R> {
         return expr.visit(this, p);
     }
 
-    R defaultValue();
+    default R defaultValue() { return null; }
 
 }
 // @formatter:on

--- a/modules/mql/src/main/java/net/hollowcube/mql/util/StringUtil.java
+++ b/modules/mql/src/main/java/net/hollowcube/mql/util/StringUtil.java
@@ -1,6 +1,12 @@
 package net.hollowcube.mql.util;
 
 import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 public final class StringUtil {
     private StringUtil() {}

--- a/modules/mql/src/test/java/net/hollowcube/mql/compile/TestBasicCompilation.java
+++ b/modules/mql/src/test/java/net/hollowcube/mql/compile/TestBasicCompilation.java
@@ -1,24 +1,73 @@
 package net.hollowcube.mql.compile;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.util.Printer;
+import org.objectweb.asm.util.Textifier;
+import org.objectweb.asm.util.TraceMethodVisitor;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 public class TestBasicCompilation {
 
     @Test
     public void experiment() throws Exception {
-        var visitor = new AsmUtil.StringClassVisitor();
-        var ctx = new Context(TestEntityQuery.class, Object.class, visitor);
+        var compiler = new MqlCompiler<>(Object.class, Object.class);
+        byte[] bytecode = compiler.compileBytecode("1 + 2");
 
-        ctx.begin();
-        var expr = net.hollowcube.mql.MqlScript.parse("q.is_alive").expr();
-        new MqlCompilerOld().visit(expr, ctx);
-        byte[] classData = ctx.end();
+        var str = prettyPrintEvalMethod(bytecode);
+        System.out.println(str);
 
-        System.out.println(visitor.bytecode());
-
-        Class<MqlScript<TestEntityQuery, Object>> c = AsmUtil.loadClass("mql$todo_add_better_name", classData);
-        var script = c.newInstance();
-        System.out.println("result: " + script.evaluate(new TestEntityQuery(), new Object()));
+//        var cw = new ClassWriter(cr, ClassWriter.COMPUTE_MAXS);
+//
+//        var visitor = new InstrumentationClassVisitor(Opcodes.ASM9, cw);
+//        visitor.visitSource("TestBasicCompilation.java", null);
+//
+//        var visitor = new AsmUtil.StringClassVisitor();
+//        var ctx = new Context(TestEntityQuery.class, Object.class, visitor);
+//
+//        ctx.begin();
+//        var expr = net.hollowcube.mql.MqlScript.parse("q.is_alive").expr();
+//        new MqlCompilerOld().visit(expr, ctx);
+//        byte[] classData = ctx.end();
+//
+//        System.out.println(visitor.bytecode());
+//
+//        Class<MqlScript<TestEntityQuery, Object>> c = AsmUtil.loadClass("mql$todo_add_better_name", classData);
+//        var script = c.newInstance();
+//        System.out.println("result: " + script.evaluate(new TestEntityQuery(), new Object()));
     }
 
+    private static @NotNull String prettyPrintEvalMethod(byte[] bytecode) {
+        var str = new StringBuilder();
+        var printer = new Textifier();
+        var mp = new TraceMethodVisitor(printer);
+
+        var cr = new ClassReader(bytecode);
+        var cn = new ClassNode();
+        cr.accept(cn, 0);
+        for (var method : cn.methods) {
+            // Ignore any method that isnt evaluate and not a bridge (we want the concrete impl)
+            if (!"evaluate".equals(method.name) || (method.access & Opcodes.ACC_BRIDGE) != 0)
+                continue;
+            InsnList insns = method.instructions;
+            for (var insn : insns) {
+                insn.accept(mp);
+                StringWriter sw = new StringWriter();
+                printer.print(new PrintWriter(sw));
+                printer.getText().clear();
+                str.append(sw);
+            }
+        }
+
+        return str.toString();
+    }
 }

--- a/modules/mql/src/test/java/net/hollowcube/mql/compile/TestBasicCompilation.java
+++ b/modules/mql/src/test/java/net/hollowcube/mql/compile/TestBasicCompilation.java
@@ -11,7 +11,7 @@ public class TestBasicCompilation {
 
         ctx.begin();
         var expr = net.hollowcube.mql.MqlScript.parse("q.is_alive").expr();
-        new MqlCompiler().visit(expr, ctx);
+        new MqlCompilerOld().visit(expr, ctx);
         byte[] classData = ctx.end();
 
         System.out.println(visitor.bytecode());

--- a/modules/mql/src/test/java/net/hollowcube/mql/compile/TestBasicCompilation.java
+++ b/modules/mql/src/test/java/net/hollowcube/mql/compile/TestBasicCompilation.java
@@ -1,0 +1,24 @@
+package net.hollowcube.mql.compile;
+
+import org.junit.jupiter.api.Test;
+
+public class TestBasicCompilation {
+
+    @Test
+    public void experiment() throws Exception {
+        var visitor = new AsmUtil.StringClassVisitor();
+        var ctx = new Context(TestEntityQuery.class, Object.class, visitor);
+
+        ctx.begin();
+        var expr = net.hollowcube.mql.MqlScript.parse("q.is_alive").expr();
+        new MqlCompiler().visit(expr, ctx);
+        byte[] classData = ctx.end();
+
+        System.out.println(visitor.bytecode());
+
+        Class<MqlScript<TestEntityQuery, Object>> c = AsmUtil.loadClass("mql$todo_add_better_name", classData);
+        var script = c.newInstance();
+        System.out.println("result: " + script.evaluate(new TestEntityQuery(), new Object()));
+    }
+
+}


### PR DESCRIPTION
Aims to compile MQL to java bytecode instead of using a tree walk interpreter. Would like to maintain the interpreter as a comparison point and alternative runtime.